### PR TITLE
Removed shift functionality on dye clicks.

### DIFF
--- a/main.js
+++ b/main.js
@@ -84,9 +84,8 @@ function init_dyes() {
 
 	dyebox.on('click', '.dye', function(e) {
 		var $t = $(this)
-		var k = +e.shiftKey
 		var offx = e.pageX - $t.offset().left
-		k = k || Math.round(offx / $t.width())
+		var k = Math.round(offx / $t.width())
 		var id = $t.data('id')
 		tx[k] = (tx[k] == id) ? -1 : id;
 		newstate();


### PR DESCRIPTION
Because dyes no longer use shift-clicking to determine whether to select the main or accessory dye, shift-clicking defaulting to choosing the accessory dye is obsolete.
